### PR TITLE
Fix Swagger UI in Production

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -40,6 +40,16 @@ This release focuses on enhancing the development experience by resolving Swagge
 
 ## Technical Details
 
+### Swagger/OpenAPI Documentation URLs
+
+- **Production**: https://eduapi.azurewebsites.net/api-docs/index.html
+- **Development**: https://eduapi-dev.azurewebsites.net/swagger/index.html
+- **Local Development**:
+  - HTTP: http://localhost:5141/swagger/index.html
+  - HTTPS: https://localhost:7154/swagger/index.html
+
+> The Swagger UI route is now dynamic and protocol-agnostic. In production, it is available at `/api-docs/index.html` (configurable via `Swagger:ProductionRoute` in appsettings). In development, the default route is `/swagger/index.html`. The server URL in the OpenAPI spec is set dynamically based on the current request context, ensuring correct protocol (HTTP/HTTPS) and host.
+
 - Added `PreSerializeFilters` to dynamically set server URLs based on current request context
 - Enhanced `SwaggerUIOptions` with developer-friendly defaults and improved configuration
 - Added null-safe CORS origin handling to prevent runtime exceptions

--- a/SchoolPortal.Api/Extensions/StartupExtensions.cs
+++ b/SchoolPortal.Api/Extensions/StartupExtensions.cs
@@ -7,7 +7,7 @@ public static class StartupExtensions
 {
     public static void ServiceCollectionExtensions(this IServiceCollection services, IConfiguration configuration)
     {
-        AddSwager(services);
+        AddSwagger(services, configuration);
         AddCors(services, configuration);
 
         services.AddSingleton<IDbConnectionFactory>(
@@ -16,24 +16,28 @@ public static class StartupExtensions
 
     public static void WebApplicationExtensions(this WebApplication app)
     {
-        ConfigureSwager(app);
+        ConfigureSwagger(app);
         ConfigureMiddleware(app);
     }
 
-    private static void AddSwager(IServiceCollection services)
+    private static void AddSwagger(IServiceCollection services, IConfiguration configuration)
     {
         services.AddEndpointsApiExplorer();
         services.AddSwaggerGen(s =>
         {
+            s.SupportNonNullableReferenceTypes();
+
             s.SwaggerDoc("v1", new OpenApiInfo
             {
                 Title = "SchoolPortal API",
-                Version = "v1",
                 Description = "School Portal API for education information management",
                 Contact = new OpenApiContact
                 {
-                    Name = "SchoolPortal Team"
-                }
+                    Name = "© DevOcean Solutions",
+                    Email = "",
+                    Url = new Uri("https://devocean.services/")
+                },
+                Version = "v1"
             });
             s.EnableAnnotations();
         });
@@ -67,13 +71,19 @@ public static class StartupExtensions
         });
     }
 
-    private static void ConfigureSwager(WebApplication app)
+    private static void ConfigureSwagger(WebApplication app)
     {
-        if (app.Environment.IsDevelopment())
+        var enableSwaggerInProduction = app.Configuration.GetValue<bool>("Swagger:EnableInProduction", false);
+        var productionRoute = app.Configuration.GetValue<string>("Swagger:ProductionRoute", "api-docs");
+        
+        if (app.Environment.IsDevelopment() || (app.Environment.IsProduction() && enableSwaggerInProduction))
         {
+            // Use different route in production for security
+            var swaggerRoute = app.Environment.IsProduction() ? productionRoute : "swagger";
+            
             app.UseSwagger(c =>
             {
-                c.RouteTemplate = "swagger/{documentName}/swagger.json";
+                c.RouteTemplate = $"{swaggerRoute}/{{documentName}}/swagger.json";
                 c.PreSerializeFilters.Add((swaggerDoc, httpReq) =>
                 {
                     var serverUrl = $"{httpReq.Scheme}://{httpReq.Host.Value}";
@@ -85,12 +95,21 @@ public static class StartupExtensions
             });
             app.UseSwaggerUI(s =>
             {
-                s.SwaggerEndpoint("/swagger/v1/swagger.json", "SchoolPortal API v1");
-                s.RoutePrefix = "swagger";
-                s.DocumentTitle = "SchoolPortal API Documentation";
+                s.SwaggerEndpoint($"/{swaggerRoute}/v1/swagger.json", "SchoolPortal API v1");
+                s.RoutePrefix = swaggerRoute;
+                s.DocumentTitle = app.Environment.IsProduction() ? 
+                    "SchoolPortal API Documentation" : 
+                    "SchoolPortal API Documentation (Development)";
                 s.DisplayRequestDuration();
                 s.EnableTryItOutByDefault();
                 s.ConfigObject.AdditionalItems.Add("syntaxHighlight", true);
+                
+                // Production-specific customizations
+                if (app.Environment.IsProduction())
+                {
+                    s.DocExpansion(Swashbuckle.AspNetCore.SwaggerUI.DocExpansion.None);
+                    s.DefaultModelsExpandDepth(-1); // Hide models section by default in production
+                }
             });
         }
     }

--- a/SchoolPortal.Api/appsettings.json
+++ b/SchoolPortal.Api/appsettings.json
@@ -23,5 +23,9 @@
   },
   "OpenTelemetry": {
     "SigNozEndpoint": "http://signozdo.eastus.cloudapp.azure.com:4317"
-  }
+  },
+  "Swagger": {
+    "EnableInProduction": true,
+    "ProductionRoute": "api-docs"
+    }
 }

--- a/docs/API.md
+++ b/docs/API.md
@@ -638,19 +638,21 @@ Error codes:
 
 ## API Documentation
 
-### Swagger
+### Swagger & OpenAPI Documentation
 
-- **Description**: Interactive API documentation interface with try-it-out functionality
-- **Production**: https://eduapi.azurewebsites.net/swagger/index.html
+- **Description**: Interactive API documentation interface. The Swagger UI route is now dynamic and protocol-agnostic, adapting to the environment (development or production).
+
+- **Production**: https://eduapi.azurewebsites.net/api-docs/index.html
 - **Development**: https://eduapi-dev.azurewebsites.net/swagger/index.html
 - **Local Development**:
   - HTTP: http://localhost:5141/swagger/index.html
   - HTTPS: https://localhost:7154/swagger/index.html
 
-#### Local Development Notes
+#### Notes
 
-- The API supports both HTTP and HTTPS protocols for local development
-- Swagger UI automatically detects and uses the correct server URL based on your current protocol
-- If experiencing rendering issues in Microsoft Edge, clear browser cache
-- Use `dotnet run` for HTTP or `dotnet run --urls=https://localhost:7154` for HTTPS
-- Development certificate may be required for HTTPS: `dotnet dev-certs https --trust`
+- In production, the Swagger UI is available at `/api-docs/index.html` (configurable via `Swagger:ProductionRoute` in appsettings).
+- In development, the default route is `/swagger/index.html`.
+- The server URL in the OpenAPI spec is set dynamically based on the current request context, ensuring correct protocol (HTTP/HTTPS) and host.
+- If experiencing rendering issues in Microsoft Edge, clear browser cache.
+- Use `dotnet run` for HTTP or `dotnet run --urls=https://localhost:7154` for HTTPS.
+- Development certificate may be required for HTTPS: `dotnet dev-certs https --trust`.


### PR DESCRIPTION
Fixed: Swagger UI inaccessible in Production environment (returning 404) - Swagger was configured to only work in Development environment (app.Environment.IsDevelopment()), making it completely inaccessible in Production.
Updated: Documentation