### PR TITLE
Institution average successes make grade optional

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,16 +1,69 @@
+# ========================================
+# .NET Build Outputs
+# ========================================
+[Bb]in/
+[Oo]bj/
 [Dd]ebug/
 [Rr]elease/
 build/
+
+# ========================================
+# Package Management
+# ========================================
 packages/
-[Bb]in/
-[Oo]bj/
+
+# ========================================
+# IDE & Editor Files
+# ========================================
+# Visual Studio
 .vs/
+*.suo
+*.user
+
+# Visual Studio Code
 .vscode/
+
+# JetBrains Rider
+.idea/
+
+# ========================================
+# Temporary & System Files
+# ========================================
 *.tmp
 *.orig
-*.suo
-*.sln.cache
-*.user
+
+# Legacy/Obsolete
 *.sql.design
 *.lutconfig
 /DeleteBinObjFolders.bat
+
+# ========================================
+# Code Coverage & Testing
+# ========================================
+# Test Results
+TestResults/
+**/TestResults/
+
+# Coverage Reports
+CoverageReport/
+**/CoverageReport/
+coverage.cobertura.xml
+**/coverage.cobertura.xml
+*.coverage
+*.coveragexml
+
+# ========================================
+# SchoolPortal Configuration
+# ========================================
+# Environment-specific settings (may contain secrets)
+**/appsettings.Development.json
+**/appsettings.Local.json
+
+# ========================================
+# Operating System Files
+# ========================================
+# macOS
+.DS_Store
+
+# Windows
+Thumbs.db

--- a/CodeCoverage.runsettings
+++ b/CodeCoverage.runsettings
@@ -1,0 +1,14 @@
+<!-- CodeCoverage.runsettings -->
+<RunSettings>
+  <DataCollectionRunSettings>
+    <DataCollectors>
+      <DataCollector friendlyName="XPlat code coverage">
+        <Configuration>
+          <Format>cobertura</Format>
+          <Exclude>[*Tests]*</Exclude>
+          <Include>[SchoolPortal.Api]*</Include>
+        </Configuration>
+      </DataCollector>
+    </DataCollectors>
+  </DataCollectionRunSettings>
+</RunSettings>

--- a/README.md
+++ b/README.md
@@ -123,7 +123,11 @@ curl -X GET https://eduapi.azurewebsites.net/api/v1/institutions/123
 #### Get Exam Results for Multiple Years
 
 ```bash
+# Get exam results for specific grade across multiple years
 curl -X GET "https://eduapi.azurewebsites.net/api/v1/institutions/123/average-successes?schoolYear=2020&schoolYear=2021&schoolYear=2022&grade=7"
+
+# Get exam results for ALL grades across multiple years
+curl -X GET "https://eduapi.azurewebsites.net/api/v1/institutions/123/average-successes?schoolYear=2020&schoolYear=2021&schoolYear=2022"
 ```
 
 #### Get Sciences for Specific School Year

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,56 @@
+# Release v1.5.0
+
+## Overview
+
+This minor release enhances the institution average successes endpoint by making the grade parameter optional, allowing queries across all grades simultaneously. This improvement provides greater flexibility for analyzing exam results and enables comprehensive institutional performance comparisons.
+
+## New Features
+
+- **Optional Grade Parameter**: The `/api/v1/institutions/{institutionId}/average-successes` endpoint now accepts an optional grade parameter
+- **Enhanced Validation**: Improved validation logic for school year arrays with better error messaging
+
+## Improvements, Fixes & Technical Changes
+
+- **API Enhancement**: Made the `grade` parameter optional in the GetInstitutionAverageSuccesses endpoint
+- **Database Schema**: Updated stored procedure `[Application].[usp_GetExamResults]` to handle optional grade filtering with `@Grade INT = NULL`
+- **Repository Pattern**: Enhanced repository interface and implementation to support optional grade parameter
+- **Validation**: Added proper validation for empty or null school year arrays
+- **Type Safety**: Fixed return type mapping in endpoint configuration from `GetFilteredProfilesResponse` to `GetExamResultsResponse`
+- **Test Coverage**: Added comprehensive unit and integration tests for optional grade functionality
+- **Code Quality**: Improved .gitignore file organization and structure
+
+## API Changes
+
+The **GET /api/v1/institutions/{institutionId}/average-successes** endpoint now supports optional grade filtering:
+
+```bash
+# Get exam results for specific grade across multiple years
+GET /api/v1/institutions/256/average-successes?schoolYear=2022&schoolYear=2023&grade=7
+
+# Get exam results for ALL grades across multiple years (new functionality)
+GET /api/v1/institutions/256/average-successes?schoolYear=2022&schoolYear=2023
+```
+
+## Database Changes
+
+- Updated `[Application].[usp_GetExamResults]` stored procedure:
+  - Added default value `NULL` for `@Grade` parameter
+  - Modified WHERE clause to support optional grade filtering: `(@Grade IS NULL OR [Grade] = @Grade)`
+
+## Technical Details
+
+### Breaking Changes
+
+**None - this is a backward-compatible enhancement.**
+
+### Validation Rules
+
+- **School Year Array**: Must contain at least one valid school year (2010-2030)
+- **Grade Parameter**: Optional - when provided, must be one of: 4, 7, 10, 12
+- **Error Handling**: Enhanced error messages for array validation scenarios
+
+<br><br>
+
 # Release v1.4.1
 
 ## Overview
@@ -15,6 +68,8 @@ The following origin has been added to the allowed origins list:
 - `https://kandidatstvam.bg`
 
 This change enables the SchoolPortal API to accept cross-origin requests from the kandidatstvam.bg domain, maintaining the existing security policies including credential support and preflight caching.
+
+<br><br>
 
 # Release v1.4.0
 
@@ -74,6 +129,8 @@ This release focuses on enhancing the development experience by resolving Swagge
 - Updated NuGet packages to latest stable versions, including major Swashbuckle update for better OpenAPI 3.0.4 support
 - Migrated from FluentValidation.AspNetCore to standalone FluentValidation package for improved compatibility
 
+<br><br>
+
 # Release v1.3.0
 
 ## Overview
@@ -110,9 +167,7 @@ This release introduces school year-aware science data retrieval and implements 
 - Updated `[Application].[uv_Sciences]` view to include school year information
 - Modified `[Application].[usp_GetAllSciences]` stored procedure to filter by school year
 
-<div style="margin: 24px 0; padding: 8px 0;">
-    <hr style="height: 3px; background-color:rgb(21, 57, 156); border: none;">
-</div>
+<br><br>
 
 # Release v1.2.0
 
@@ -129,6 +184,8 @@ This release enhances the project documentation and reinforces centralized packa
 
 - Revised documentation content for improved clarity
 - No modifications to licensing terms
+
+<br><br>
 
 # Release v1.1.0
 
@@ -154,9 +211,7 @@ This release enhances the SchoolPortal API with support for multi-year data anal
   GET /api/v1/institutions/2546/average-successes?schoolYear=2020&schoolYear=2021&schoolYear=2022&grade=7
 ```
 
-<div style="margin: 24px 0; padding: 8px 0;">
-    <hr style="height: 3px; background-color:rgb(21, 57, 156); border: none;">
-</div>
+<br><br>
 
 # Release v1.0.0 - Initial Release
 

--- a/SchoolPortal.Api/Endpoints/Institutions.cs
+++ b/SchoolPortal.Api/Endpoints/Institutions.cs
@@ -23,7 +23,7 @@ public class Institutions : IEndpoint
 
         app.MapGet("/api/v1/institutions/{institutionId:int}/average-successes", GetInstitutionAverageSuccesses)
             .WithName("GetInstitutionAverageSuccesses")
-            .Produces<GetFilteredProfilesResponse>(StatusCodes.Status200OK)
+            .Produces<GetExamResultsResponse>(StatusCodes.Status200OK)
             .RequireCors("AllowedOriginsPolicy");
     }
 
@@ -80,7 +80,7 @@ public class Institutions : IEndpoint
         int institutionId,
         HttpContext httpContext,
         [FromQuery] int[] schoolYear,
-        [FromQuery] int grade,
+        [FromQuery] int? grade,
         [FromServices] IInstitutionRepository institutionRepository)
     {
         httpContext.Response.Headers["Deprecated"] = "False";
@@ -88,20 +88,33 @@ public class Institutions : IEndpoint
         var schoolYearValidator = new SchoolYearValidator();
         var gradeValidator = new GradeValidator();
 
-        var schoolYearValidationResult = new FluentValidation.Results.ValidationResult();
+        var validationResults = new FluentValidation.Results.ValidationResult();
 
-        foreach (var year in schoolYear)
+        // Validate that schoolYear array is not empty or null
+        if (schoolYear == null || schoolYear.Length == 0)
         {
-            var validationResult = schoolYearValidator.Validate(year);
-            schoolYearValidationResult.Errors.AddRange(validationResult.Errors);
+            validationResults.Errors.Add(new FluentValidation.Results.ValidationFailure(
+                "schoolYear", "At least one school year must be provided."));
+        }
+        else
+        {
+            // Validate all school years using the same validator instance
+            foreach (var year in schoolYear)
+            {
+                var yearValidationResult = schoolYearValidator.Validate(year);
+                validationResults.Errors.AddRange(yearValidationResult.Errors);
+            }
         }
 
-        var gradeValidationResult = gradeValidator.Validate(grade);
-
-        if (!schoolYearValidationResult.IsValid || !gradeValidationResult.IsValid)
+        if (grade is not null)
         {
-            var allErrors = schoolYearValidationResult.Errors.Concat(gradeValidationResult.Errors).ToList();
-            throw new ValidationException(allErrors);
+            var gradeValidationResult = gradeValidator.Validate(grade.Value);
+            validationResults.Errors.AddRange(gradeValidationResult.Errors);
+        }
+
+        if (!validationResults.IsValid)
+        {
+            throw new ValidationException(validationResults.Errors);
         }
 
         var examResults = await institutionRepository.GetInstitutionAverageSuccesses(institutionId, schoolYear, grade);

--- a/SchoolPortal.Api/Repositories/InstitutionRepository.cs
+++ b/SchoolPortal.Api/Repositories/InstitutionRepository.cs
@@ -9,7 +9,7 @@ public interface IInstitutionRepository
 {
     Task<InstitutionModel> GetInstitutionById(int institutionId);
     Task<IReadOnlyCollection<ProfileModel>> GetInstitutionProfiles(int institutionId, int schoolYear, int? grade);
-    Task<IReadOnlyCollection<ExamResultModel>> GetInstitutionAverageSuccesses(int institutionId, int[] schoolYears, int grade);
+    Task<IReadOnlyCollection<ExamResultModel>> GetInstitutionAverageSuccesses(int institutionId, int[] schoolYears, int? grade);
 }
 
 public class InstitutionRepository : IInstitutionRepository
@@ -68,7 +68,7 @@ public class InstitutionRepository : IInstitutionRepository
         return profiles;
     }
 
-    public async Task<IReadOnlyCollection<ExamResultModel>> GetInstitutionAverageSuccesses(int institutionId, int[] schoolYears, int grade)
+    public async Task<IReadOnlyCollection<ExamResultModel>> GetInstitutionAverageSuccesses(int institutionId, int[] schoolYears, int? grade)
     {
         await using var connection = await connectionFactory.CreateConnectionAsync();
         var parameters = new DynamicParameters();
@@ -83,7 +83,7 @@ public class InstitutionRepository : IInstitutionRepository
 
         parameters.Add("@InstitutionId", institutionId, DbType.Int32);
         parameters.Add("@SchoolYears", schoolYearsTable.AsTableValuedParameter("Application.SchoolYearsList"));
-        parameters.Add("@Grade", grade, DbType.Int32);
+        parameters.Add("@Grade", grade ?? (object)DBNull.Value, DbType.Int32);
 
         return [.. (await connection.QueryAsync<ExamResultModel>(
                 sql: "[Application].[usp_GetExamResults]",

--- a/SchoolPortal.Database.Deploy/AlwaysRun/StoredProcedures/[Application].[usp_GetExamResults].sql
+++ b/SchoolPortal.Database.Deploy/AlwaysRun/StoredProcedures/[Application].[usp_GetExamResults].sql
@@ -12,7 +12,7 @@ GO
 CREATE OR ALTER PROC [Application].[usp_GetExamResults]
     @InstitutionId	INT,
     @SchoolYears	[Application].[SchoolYearsList] READONLY,
-    @Grade			INT
+    @Grade			INT	= NULL
 AS
 BEGIN
 	SET NOCOUNT ON;
@@ -31,8 +31,8 @@ BEGIN
 	FROM
 		[Application].[uv_ExamResults]
 	WHERE
-		[InstitutionId] = @InstitutionId AND
-		[SchoolYear] IN (SELECT [Year] FROM @SchoolYears) AND
-		[Grade] = @Grade
+			(InstitutionId = @InstitutionId)
+		AND (SchoolYear IN (SELECT [Year] FROM @SchoolYears))
+		AND (@Grade IS NULL OR [Grade] = @Grade )
 END;
 GO

--- a/SchoolPortal.Database.Deploy/SchoolPortal.Database.Deploy.csproj
+++ b/SchoolPortal.Database.Deploy/SchoolPortal.Database.Deploy.csproj
@@ -9,10 +9,6 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="coverlet.collector">
-			<PrivateAssets>all</PrivateAssets>
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
 		<PackageReference Include="dbup-sqlserver" />
 		<PackageReference Include="Microsoft.Extensions.Configuration" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" />

--- a/SchoolPortal.IntegrationTests/InstitutionsTests.cs
+++ b/SchoolPortal.IntegrationTests/InstitutionsTests.cs
@@ -379,7 +379,8 @@ public class InstitutionsTests : IAsyncLifetime, IClassFixture<SchoolPortalApiAp
         Assert.NotNull(errorResponse.Errors);
 
         Assert.Contains($"Provided year ({invalidYear}) must be between",
-                      errorResponse.Errors.First(e => e.Contains(invalidYear.ToString())));
+            errorResponse.Errors.First(e => e.Contains(invalidYear.ToString()))
+        );
     }
 
     [Fact]
@@ -402,6 +403,7 @@ public class InstitutionsTests : IAsyncLifetime, IClassFixture<SchoolPortalApiAp
         foreach (var (year, index) in manyYears.Select((y, i) => (y, i)))
         {
             var schoolYearId = await dataSeeder.SeedSchoolYear(year);
+
             await dataSeeder.SeedExamResults(
                 50 + index,
                 60.0M + index,
@@ -409,7 +411,8 @@ public class InstitutionsTests : IAsyncLifetime, IClassFixture<SchoolPortalApiAp
                 subjectAbbreviationId,
                 subInstitutionId,
                 schoolYearId,
-                examAbbreviationId);
+                examAbbreviationId
+            );
         }
 
         var queryParameters = string.Join("&", manyYears.Select(y => $"schoolYear={y}")) + $"&grade={grade}";
@@ -438,5 +441,197 @@ public class InstitutionsTests : IAsyncLifetime, IClassFixture<SchoolPortalApiAp
             Assert.True(orderedResults[i].CandidateCount > orderedResults[i - 1].CandidateCount,
                 "Candidate counts should increase with each year");
         }
+    }
+
+    [Fact]
+    public async Task GetInstitutionAverageSuccesses_ReturnsBadRequest_WhenSchoolYearArrayIsEmpty()
+    {
+        // Arrange
+        var institutionId = 12345;
+
+        // Act - calling endpoint without any schoolYear parameters
+        var response = await httpClient.GetAsync($"/api/v1/institutions/{institutionId}/average-successes");
+
+        // Assert
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+
+        var errorResponse = await response.Content.ReadFromJsonAsync<ErrorResponse>();
+        Assert.NotNull(errorResponse);
+        Assert.NotNull(errorResponse.Errors);
+        Assert.Contains("At least one school year must be provided",
+            errorResponse.Errors.First(e => e.Contains("school year")));
+    }
+
+    [Fact]
+    public async Task GetInstitutionAverageSuccesses_ReturnsAllGrades_WhenGradeParameterIsNotProvided()
+    {
+        // Arrange
+        var schoolYears = new[] { 2023, 2024 };
+        var grade7 = 7;
+        var grade10 = 10;
+        var subjectAbbreviationBEL = "БЕЛ";
+        var examAbbreviation = "НВО";
+
+        var settlement = "София";
+        var neighbourhood = "Лозенец";
+
+        var addressId = await dataSeeder.SeedNeighbourhood(settlement, neighbourhood);
+        var examAbbreviationId = await dataSeeder.SeedExamAbbreviation(examAbbreviation);
+        var subjectAbbreviationId = await dataSeeder.SeedSubjectAbbreviation(subjectAbbreviationBEL);
+
+        var institutionId = await dataSeeder.SeedInstitution(12345, "Test Institution Optional Grade", "TIOG");
+        var subInstitutionId = await dataSeeder.SeedSubInstitution(institutionId, addressId);
+
+        // Seed data for multiple grades across multiple years
+        foreach (var year in schoolYears)
+        {
+            var schoolYearId = await dataSeeder.SeedSchoolYear(year);
+
+            await dataSeeder.SeedExamResults(
+                50, 65.5M, grade7, subjectAbbreviationId,
+                subInstitutionId, schoolYearId, examAbbreviationId);
+
+            await dataSeeder.SeedExamResults(
+                40, 72.3M, grade10, subjectAbbreviationId,
+                subInstitutionId, schoolYearId, examAbbreviationId);
+        }
+
+        var queryParameters = string.Join("&", schoolYears.Select(y => $"schoolYear={y}"));
+
+        // Act
+        var response = await httpClient.GetAsync($"/api/v1/institutions/{subInstitutionId}/average-successes?{queryParameters}");
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var examResultsResponse = await response.Content.ReadFromJsonAsync<GetExamResultsResponse>();
+        Assert.NotNull(examResultsResponse);
+        Assert.NotNull(examResultsResponse.ExamResults);
+        Assert.NotEmpty(examResultsResponse.ExamResults);
+
+        Assert.Equal(4, examResultsResponse.ExamResultsCount);
+        Assert.Equal(4, examResultsResponse.ExamResults.Count);
+
+        var grade7Results = examResultsResponse.ExamResults.Where(r => r.Grade == grade7);
+        var grade10Results = examResultsResponse.ExamResults.Where(r => r.Grade == grade10);
+
+        Assert.Equal(2, grade7Results.Count());
+        Assert.Equal(2, grade10Results.Count());
+
+        Assert.Contains(schoolYears[0], examResultsResponse.ExamResults.Select(x => x.SchoolYear));
+        Assert.Contains(schoolYears[1], examResultsResponse.ExamResults.Select(x => x.SchoolYear));
+
+        Assert.All(examResultsResponse.ExamResults, examResult =>
+        {
+            Assert.Equal(examAbbreviation, examResult.ExamAbbreviation);
+            Assert.Equal(subjectAbbreviationBEL, examResult.SubjectAbbreviation);
+            Assert.Equal(subInstitutionId, examResult.InstitutionId);
+            Assert.True(examResult.Grade == grade7 || examResult.Grade == grade10);
+        });
+    }    
+
+    [Fact]
+    public async Task GetInstitutionAverageSuccesses_ReturnsResultsWithMixedGrades_WhenGradeParameterIsOptional()
+    {
+        // Arrange
+        var schoolYears = new[] { 2023 };
+        var grade4 = 4;
+        var grade7 = 7;
+        var grade12 = 12;
+        var subjectAbbreviation = "БЕЛ";
+        var examAbbreviation = "НВО";
+
+        var settlement = "София";
+        var neighbourhood = "Лозенец";
+
+        var addressId = await dataSeeder.SeedNeighbourhood(settlement, neighbourhood);
+        var examAbbreviationId = await dataSeeder.SeedExamAbbreviation(examAbbreviation);
+        var subjectAbbreviationId = await dataSeeder.SeedSubjectAbbreviation(subjectAbbreviation);
+
+        var institutionId = await dataSeeder.SeedInstitution(98765, "Mixed Grades Institution", "MGI");
+        var subInstitutionId = await dataSeeder.SeedSubInstitution(institutionId, addressId);
+
+        var schoolYearId = await dataSeeder.SeedSchoolYear(schoolYears[0]);
+
+        await dataSeeder.SeedExamResults(30, 55.0M, grade4, subjectAbbreviationId, subInstitutionId, schoolYearId, examAbbreviationId);
+        await dataSeeder.SeedExamResults(50, 65.0M, grade7, subjectAbbreviationId, subInstitutionId, schoolYearId, examAbbreviationId);
+        await dataSeeder.SeedExamResults(25, 75.0M, grade12, subjectAbbreviationId, subInstitutionId, schoolYearId, examAbbreviationId);
+
+        var queryParameters = string.Join("&", schoolYears.Select(y => $"schoolYear={y}"));
+
+        // Act - request without grade parameter to get all grades
+        var response = await httpClient.GetAsync($"/api/v1/institutions/{subInstitutionId}/average-successes?{queryParameters}");
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var examResultsResponse = await response.Content.ReadFromJsonAsync<GetExamResultsResponse>();
+        Assert.NotNull(examResultsResponse);
+        Assert.Equal(3, examResultsResponse.ExamResultsCount);
+
+        var grades = examResultsResponse.ExamResults.Select(r => r.Grade).Distinct().OrderBy(g => g).ToArray();
+        Assert.Equal(new[] { grade4, grade7, grade12 }, grades);
+
+        var grade4Result = examResultsResponse.ExamResults.First(r => r.Grade == grade4);
+        var grade7Result = examResultsResponse.ExamResults.First(r => r.Grade == grade7);
+        var grade12Result = examResultsResponse.ExamResults.First(r => r.Grade == grade12);
+
+        Assert.Equal(55.0M, grade4Result.AverageScore);
+        Assert.Equal(65.0M, grade7Result.AverageScore);
+        Assert.Equal(75.0M, grade12Result.AverageScore);
+    }
+
+    [Fact]
+    public async Task GetInstitutionAverageSuccesses_ComparesBehavior_WithAndWithoutGradeParameter()
+    {
+        // Arrange
+        var schoolYears = new[] { 2023 };
+        var targetGrade = 7;
+        var otherGrade = 10;
+        var subjectAbbreviation = "БЕЛ";
+        var examAbbreviation = "НВО";
+
+        var settlement = "София";
+        var neighbourhood = "Лозенец";
+
+        var addressId = await dataSeeder.SeedNeighbourhood(settlement, neighbourhood);
+        var examAbbreviationId = await dataSeeder.SeedExamAbbreviation(examAbbreviation);
+        var subjectAbbreviationId = await dataSeeder.SeedSubjectAbbreviation(subjectAbbreviation);
+
+        var institutionId = await dataSeeder.SeedInstitution(11111, "Comparison Test Institution", "CTI");
+        var subInstitutionId = await dataSeeder.SeedSubInstitution(institutionId, addressId);
+
+        var schoolYearId = await dataSeeder.SeedSchoolYear(schoolYears[0]);
+
+        await dataSeeder.SeedExamResults(40, 68.5M, targetGrade, subjectAbbreviationId, subInstitutionId, schoolYearId, examAbbreviationId);
+        await dataSeeder.SeedExamResults(35, 73.2M, otherGrade, subjectAbbreviationId, subInstitutionId, schoolYearId, examAbbreviationId);
+
+        var baseQuery = string.Join("&", schoolYears.Select(y => $"schoolYear={y}"));
+
+        // Act 1 - Request with specific grade
+        var responseWithGrade = await httpClient.GetAsync($"/api/v1/institutions/{subInstitutionId}/average-successes?{baseQuery}&grade={targetGrade}");
+
+        // Act 2 - Request without grade (should return all grades)
+        var responseWithoutGrade = await httpClient.GetAsync($"/api/v1/institutions/{subInstitutionId}/average-successes?{baseQuery}");
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, responseWithGrade.StatusCode);
+        Assert.Equal(HttpStatusCode.OK, responseWithoutGrade.StatusCode);
+
+        var resultsWithGrade = await responseWithGrade.Content.ReadFromJsonAsync<GetExamResultsResponse>();
+        var resultsWithoutGrade = await responseWithoutGrade.Content.ReadFromJsonAsync<GetExamResultsResponse>();
+
+        Assert.NotNull(resultsWithGrade);
+        Assert.NotNull(resultsWithoutGrade);
+
+        // With grade: should return only 1 result (specific grade)
+        Assert.Equal(1, resultsWithGrade.ExamResultsCount);
+        Assert.Equal(targetGrade, resultsWithGrade.ExamResults.First().Grade);
+        Assert.Equal(68.5M, resultsWithGrade.ExamResults.First().AverageScore);
+
+        // Without grade: should return 2 results (all grades)
+        Assert.Equal(2, resultsWithoutGrade.ExamResultsCount);
+        Assert.Contains(resultsWithoutGrade.ExamResults, r => r.Grade == targetGrade && r.AverageScore == 68.5M);
+        Assert.Contains(resultsWithoutGrade.ExamResults, r => r.Grade == otherGrade && r.AverageScore == 73.2M);
     }
 }

--- a/SchoolPortal.UnitTests/Endpoints/InstitutionsEndpointsTests.cs
+++ b/SchoolPortal.UnitTests/Endpoints/InstitutionsEndpointsTests.cs
@@ -216,4 +216,93 @@ public class InstitutionsEndpointsTests
         Assert.Equal(0, response.ExamResultsCount);
         Assert.Empty(response.ExamResults);
     }
+
+    [Fact]
+    public async Task GetInstitutionAverageSuccesses_ReturnsOk_WhenGradeIsNull()
+    {
+        // Arrange
+        var institutionId = 1;
+        var schoolYears = new int[] { 2023, 2024 };
+        int? grade = null; // Testing optional grade functionality
+        var examResults = new List<ExamResultModel>
+        {
+            It.IsAny<ExamResultModel>(),
+            It.IsAny<ExamResultModel>()
+        };
+
+        institutionRepositoryMock
+            .Setup(repo => repo.GetInstitutionAverageSuccesses(institutionId, schoolYears, grade))
+            .ReturnsAsync(examResults);
+
+        // Act
+        var result = await institutionsEndpoint.GetInstitutionAverageSuccesses(
+            institutionId,
+            httpContext,
+            schoolYears,
+            grade,
+            institutionRepositoryMock.Object);
+
+        // Assert
+        Assert.IsType<Ok<GetExamResultsResponse>>(result);
+        var okResult = result as Ok<GetExamResultsResponse>;
+        Assert.Equal(StatusCodes.Status200OK, okResult?.StatusCode);
+
+        var response = okResult?.Value;
+
+        Assert.NotNull(response);
+        Assert.Equal(examResults.Count, response.ExamResultsCount);
+        Assert.Equal(examResults, response.ExamResults);
+        
+        // Verify repository was called with null grade
+        institutionRepositoryMock.Verify(
+            repo => repo.GetInstitutionAverageSuccesses(institutionId, schoolYears, null),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task GetInstitutionAverageSuccesses_ThrowsValidationException_WhenSchoolYearArrayIsEmpty()
+    {
+        // Arrange
+        var institutionId = 1;
+        var schoolYears = new int[] { };
+        int? grade = 7;
+
+        // Act & Assert
+        await Assert.ThrowsAsync<FluentValidation.ValidationException>(async () =>
+            await institutionsEndpoint.GetInstitutionAverageSuccesses(
+                institutionId,
+                httpContext,
+                schoolYears,
+                grade,
+                institutionRepositoryMock.Object));
+
+        // Verify repository was never called due to validation failure
+        institutionRepositoryMock.Verify(
+            repo => repo.GetInstitutionAverageSuccesses(It.IsAny<int>(), It.IsAny<int[]>(), It.IsAny<int?>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task GetInstitutionAverageSuccesses_ThrowsValidationException_WhenSchoolYearArrayIsNull()
+    {
+        // Arrange
+        var institutionId = 1;
+        int[] schoolYears = null!;
+        int? grade = 7;
+
+        // Act & Assert
+        await Assert.ThrowsAsync<FluentValidation.ValidationException>(async ()
+            => await institutionsEndpoint.GetInstitutionAverageSuccesses(
+                institutionId,
+                httpContext,
+                schoolYears,
+                grade,
+                institutionRepositoryMock.Object)
+        );
+
+        // Verify repository was never called due to validation failure
+        institutionRepositoryMock.Verify(
+            repo => repo.GetInstitutionAverageSuccesses(It.IsAny<int>(), It.IsAny<int[]>(), It.IsAny<int?>()),
+            Times.Never);
+    }
 }

--- a/docs/API.md
+++ b/docs/API.md
@@ -438,8 +438,8 @@ GET /api/v1/profiles/sciences       # Get sciences for current year
 - **Path Parameters**:
   - `institutionId`: The unique identifier of the institution
 - **Query Parameters**:
-  - `schoolYear` (required, multiple): Academic year(s)
-  - `grade` (required): School grade
+  - `schoolYear` (required, multiple): Academic year(s) - At least one school year must be provided
+  - `grade` (optional): School grade - If not provided, returns results for all grades
 - **Response**: List of exam results with count
 
 ```json
@@ -475,12 +475,18 @@ GET /api/v1/profiles/sciences       # Get sciences for current year
 ```
 
 - **Validation Rules**:
-  - `schoolYear`: Each year must be between 2010 and 2030
-  - `grade`: Must be one of the following: 4, 7, 10, 12
-- **Example Query with Multiple Years**:
+  - `schoolYear`: Each year must be between 2010 and 2030, at least one school year must be provided
+  - `grade`: Must be one of the following: 4, 7, 10, 12 (optional parameter)
+- **Example Query with Multiple Years and Specific Grade**:
 
 ```
 GET /api/v1/institutions/256/average-successes?schoolYear=2022&schoolYear=2023&schoolYear=2024&grade=7
+```
+
+- **Example Query with Multiple Years for All Grades**:
+
+```
+GET /api/v1/institutions/256/average-successes?schoolYear=2022&schoolYear=2023&schoolYear=2024
 ```
 
 ```json


### PR DESCRIPTION
**Enhance institution average successes endpoint: make grade parameter optional, improve validation, and update documentation.**

Update the /api/v1/institutions/{institutionId:int}/average-successes endpoint so that the 'grade' query parameter is optional.

- When 'grade' is provided, the API will return average successes for the specified grade.
- When 'grade' is omitted, the API will return average successes for all available grades for the given institution and school years.

This change will improve flexibility for API consumers and support broader reporting scenarios.