### PR TITLE
Introduce 'ProfileDetails' to Use 'Education Type'

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,357 @@
+---
+description: "This file provides guidelines for coding-guidelines instructions & coding-style instructions - writing clean, maintainable, and idiomatic C# code with a focus on functional patterns and proper abstraction."
+---
+
+# Coding-Guidelines Instructions
+
+## General:
+
+**Description:**
+.Net code should be written to maximize readability, maintainability, and correctness while minimizing complexity and coupling. Prefer immutable data where appropriate, and keep abstractions simple and focused.
+
+**Requirements:**
+
+- Write clear, self-documenting code
+- Keep abstractions simple and focused
+- Minimize dependencies and coupling
+- Use modern C# features appropriately
+
+## Code Organization:
+
+- Use meaningful names for classes, methods, and variables
+- Organize code into logical namespaces based on the project and folder, where the current class is located
+- Use file-scoped namespaces
+
+- Separate state from behavior:
+
+  ```csharp
+  // Good: Behavior separate from state
+  public sealed record Order(OrderId Id, List<OrderLine> Lines);
+
+  public static class OrderOperations
+  {
+      public static decimal CalculateTotal(Order order) =>
+          order.Lines.Sum(line => line.Price * line.Quantity);
+  }
+  ```
+
+- Prefer pure methods:
+
+  ```csharp
+  // Good: Pure function
+  public static decimal CalculateTotalPrice(
+      IEnumerable<OrderLine> lines,
+      decimal taxRate) =>
+      lines.Sum(line => line.Price * line.Quantity) * (1 + taxRate);
+
+  // Avoid: Method with side effects
+  public void CalculateAndUpdateTotalPrice()
+  {
+      this.Total = this.Lines.Sum(l => l.Price * l.Quantity);
+      this.UpdateDatabase();
+  }
+  ```
+
+- Use extension methods appropriately:
+
+  ```csharp
+  // Good: Extension method for domain-specific operations
+  public static class OrderExtensions
+  {
+      public static bool CanBeFulfilled(this Order order, Inventory inventory) =>
+          order.Lines.All(line => inventory.HasStock(line.ProductId, line.Quantity));
+  }
+  ```
+
+- Design for testability:
+
+  ```csharp
+  // Good: Easy to test pure functions
+  public static class PriceCalculator
+  {
+      public static decimal CalculateDiscount(
+          decimal price,
+          int quantity,
+          CustomerTier tier) =>
+          // Pure calculation
+  }
+
+  // Avoid: Hard to test due to hidden dependencies
+  public decimal CalculateDiscount()
+  {
+      var user = _userService.GetCurrentUser();  // Hidden dependency
+      var settings = _configService.GetSettings(); // Hidden dependency
+      // Calculation
+  }
+  ```
+
+## Dependency Management:
+
+- Minimize constructor injection:
+
+  ```csharp
+  // Good: Minimal dependencies
+  public sealed class OrderProcessor(IOrderRepository repository)
+  {
+      // Implementation
+  }
+
+  // Avoid: Too many dependencies where is possible
+  // Too many dependencies indicates possible design issues
+  public class OrderProcessor(
+      IOrderRepository repository,
+      ILogger logger,
+      IEmailService emailService,
+      IMetrics metrics,
+      IValidator validator)
+  {
+      // Implementation
+  }
+  ```
+
+- Prefer composition with interfaces:
+  ```csharp
+  // Good: Composition with interfaces
+  public sealed class EnhancedLogger(ILogger baseLogger, IMetrics metrics) : ILogger
+  {
+  }
+  ```
+
+## Smart Comments
+
+- Don't comment on what the code does - make the code self-documenting
+- Use comments to explain why something is done a certain way
+- Document APIs, complex algorithms, and non-obvious side effects
+
+## Single Responsibility
+
+- Each function or method should do exactly one thing
+- It should be small and focused
+- If it needs a comment to explain what it does, it should be split
+
+## DRY (Don't Repeat Yourself)
+
+- Extract repeated code into reusable functions
+- Share common logic through proper abstraction
+- Maintain single sources of truth
+
+## Verify Information
+
+Always verify information before presenting it. Do not make assumptions or speculate without clear evidence.
+
+---
+
+# Coding-Style Instructions
+
+## Type Definitions:
+
+- Prefer records for data types where appropriate:
+
+  ```csharp
+  // Good: Immutable data type with value semantics
+  public sealed record CustomerDto(string Name, Email Email);
+
+  // Avoid: Class with mutable properties
+  public class Customer
+  {
+      public string Name { get; set; }
+      public string Email { get; set; }
+  }
+  ```
+
+## Variable Declarations:
+
+- Use var where possible:
+
+  ```csharp
+  // Good: Using var for type inference
+  var fruit = "Apple";
+  var number = 42;
+  var order = new Order(fruit, number);
+  ```
+
+- Use pattern matching effectively:
+
+  ```csharp
+  // Good: Clear pattern matching
+  public decimal CalculateDiscount(Customer customer) =>
+      customer switch
+      {
+          { Tier: CustomerTier.Premium } => 0.2m,
+          { OrderCount: > 10 } => 0.1m,
+          _ => 0m
+      };
+
+  // Avoid: Nested if statements
+  public decimal CalculateDiscount(Customer customer)
+  {
+      if (customer.Tier == CustomerTier.Premium)
+          return 0.2m;
+      if (customer.OrderCount > 10)
+          return 0.1m;
+      return 0m;
+  }
+  ```
+
+## Nullability:
+
+- Mark nullable fields explicitly:
+
+  ```csharp
+  // Good: Explicit nullability
+  public class OrderProcessor
+  {
+      private readonly ILogger<OrderProcessor>? _logger;
+      private string? _lastError;
+
+      public OrderProcessor(ILogger<OrderProcessor>? logger = null)
+      {
+          _logger = logger;
+      }
+  }
+
+  // Avoid: Implicit nullability
+  public class OrderProcessor
+  {
+      private readonly ILogger<OrderProcessor> _logger; // Warning: Could be null
+      private string _lastError; // Warning: Could be null
+  }
+  ```
+
+- Use null checks only when necessary for reference types and public methods:
+
+  ```csharp
+  // Good: Proper null checking
+  public void ProcessOrder(Order order)
+  {
+      ArgumentNullException.ThrowIfNull(order); // Appropriate for reference types
+
+      _logger?.LogInformation("Processing order {Id}", order.Id);
+  }
+
+  // Good: Using pattern matching for null checks
+  public decimal CalculateTotal(Order? order) =>
+      order switch
+      {
+          null => throw new ArgumentNullException(nameof(order)),
+          { Lines: null } => throw new ArgumentException("Order lines cannot be null", nameof(order)),
+          _ => order.Lines.Sum(l => l.Total)
+      };
+  ```
+
+- Use init-only properties with non-null validation:
+
+  ```csharp
+  // Good: Non-null validation in constructor
+  public sealed record Order
+  {
+      public required OrderId Id { get; init; }
+      public required ImmutableList<OrderLine> Lines { get; init; }
+
+      public Order()
+      {
+          Id = null!; // Will be set by required property
+          Lines = null!; // Will be set by required property
+      }
+
+      private Order(OrderId id, ImmutableList<OrderLine> lines)
+      {
+          Id = id;
+          Lines = lines;
+      }
+
+      public static Order Create(OrderId id, IEnumerable<OrderLine> lines) =>
+          new(id, lines.ToImmutableList());
+  }
+  ```
+
+- Document nullability in interfaces:
+
+  ```csharp
+  public interface IOrderRepository
+  {
+      // Explicitly shows that null is a valid return value
+      Task<Order?> FindByIdAsync(OrderId id, CancellationToken ct = default);
+
+      // Method will never return null
+      [return: NotNull]
+      Task<IReadOnlyList<Order>> GetAllAsync(CancellationToken ct = default);
+
+      // Parameter cannot be null
+      Task SaveAsync([NotNull] Order order, CancellationToken ct = default);
+  }
+  ```
+
+## Safe Operations:
+
+- Use Try methods for safer operations:
+
+  ```csharp
+  // Good: Using TryGetValue for dictionary access
+  if (dictionary.TryGetValue(key, out var value))
+  {
+      // Use value safely here
+  }
+  else
+  {
+      // Handle missing key case
+  }
+
+  // Avoid: Direct indexing which can throw
+  var value = dictionary[key];  // Throws if key doesn't exist
+  ```
+
+  ```csharp
+  // Good: Using Uri.TryCreate for URL parsing
+  if (Uri.TryCreate(urlString, UriKind.Absolute, out var uri))
+  {
+      // Use uri safely here
+  }
+  else
+  {
+      // Handle invalid URL case
+  }
+
+  // Avoid: Direct Uri creation which can throw
+    var uri = new Uri(urlString);  // Throws on invalid URL
+  ```
+
+  ```csharp
+  // Good: Using int.TryParse for number parsing
+    if (int.TryParse(input, out var number))
+    {
+        // Use number safely here
+    }
+    else
+    {
+        // Handle invalid number case
+    }
+  ```
+
+  ```csharp
+    // Good: Combining Try methods with null coalescing
+    var value = dictionary.TryGetValue(key, out var result)
+        ? result
+        : defaultValue;
+
+    // Good: Using Try methods in LINQ with pattern matching
+    var validNumbers = strings
+        .Select(s => (Success: int.TryParse(s, out var num), Value: num))
+        .Where(x => x.Success)
+        .Select(x => x.Value);
+  ```
+
+## Asynchronous Programming:
+
+- Avoid use of Task.Result, Task.Wait, Task.FromResult.
+
+- Prefer async/await over direct Task return:
+  ```csharp
+  // Good: Using async/await
+  public async Task<Order> ProcessOrderAsync(OrderRequest request)
+  {
+      await _validator.ValidateAsync(request);
+      var order = await _factory.CreateAsync(request);
+      return order;
+  }
+  ```

--- a/.github/instructions/coding-guidelines.instructions.md
+++ b/.github/instructions/coding-guidelines.instructions.md
@@ -1,0 +1,138 @@
+---
+applyTo: "**"
+description: "This file provides guidelines for coding-guidelines instructions - writing clean, maintainable, and idiomatic C# code with a focus on functional patterns and proper abstraction."
+---
+
+## General:
+
+**Description:**
+.Net code should be written to maximize readability, maintainability, and correctness while minimizing complexity and coupling. Prefer immutable data where appropriate, and keep abstractions simple and focused.
+
+**Requirements:**
+
+- Write clear, self-documenting code
+- Keep abstractions simple and focused
+- Minimize dependencies and coupling
+- Use modern C# features appropriately
+
+## Code Organization:
+
+- Use meaningful names for classes, methods, and variables
+- Organize code into logical namespaces based on the project and folder, where the current class is located
+- Use file-scoped namespaces
+
+- Separate state from behavior:
+
+  ```csharp
+  // Good: Behavior separate from state
+  public sealed record Order(OrderId Id, List<OrderLine> Lines);
+
+  public static class OrderOperations
+  {
+      public static decimal CalculateTotal(Order order) =>
+          order.Lines.Sum(line => line.Price * line.Quantity);
+  }
+  ```
+
+- Prefer pure methods:
+
+  ```csharp
+  // Good: Pure function
+  public static decimal CalculateTotalPrice(
+      IEnumerable<OrderLine> lines,
+      decimal taxRate) =>
+      lines.Sum(line => line.Price * line.Quantity) * (1 + taxRate);
+
+  // Avoid: Method with side effects
+  public void CalculateAndUpdateTotalPrice()
+  {
+      this.Total = this.Lines.Sum(l => l.Price * l.Quantity);
+      this.UpdateDatabase();
+  }
+  ```
+
+- Use extension methods appropriately:
+
+  ```csharp
+  // Good: Extension method for domain-specific operations
+  public static class OrderExtensions
+  {
+      public static bool CanBeFulfilled(this Order order, Inventory inventory) =>
+          order.Lines.All(line => inventory.HasStock(line.ProductId, line.Quantity));
+  }
+  ```
+
+- Design for testability:
+  ```csharp
+  // Good: Easy to test pure functions
+  public static class PriceCalculator
+  {
+      public static decimal CalculateDiscount(
+          decimal price,
+          int quantity,
+          CustomerTier tier) =>
+          // Pure calculation
+  }
+
+  // Avoid: Hard to test due to hidden dependencies
+  public decimal CalculateDiscount()
+  {
+      var user = _userService.GetCurrentUser();  // Hidden dependency
+      var settings = _configService.GetSettings(); // Hidden dependency
+      // Calculation
+  }
+  ```
+
+## Dependency Management:
+
+- Minimize constructor injection:
+
+  ```csharp
+  // Good: Minimal dependencies
+  public sealed class OrderProcessor(IOrderRepository repository)
+  {
+      // Implementation
+  }
+
+  // Avoid: Too many dependencies where is possible
+  // Too many dependencies indicates possible design issues
+  public class OrderProcessor(
+      IOrderRepository repository,
+      ILogger logger,
+      IEmailService emailService,
+      IMetrics metrics,
+      IValidator validator)
+  {
+      // Implementation
+  }
+  ```
+
+- Prefer composition with interfaces:
+  ```csharp
+  // Good: Composition with interfaces
+  public sealed class EnhancedLogger(ILogger baseLogger, IMetrics metrics) : ILogger
+  {
+  }
+  ```
+
+## Smart Comments
+
+- Don't comment on what the code does - make the code self-documenting
+- Use comments to explain why something is done a certain way
+- Document APIs, complex algorithms, and non-obvious side effects
+
+## Single Responsibility
+
+- Each function or method should do exactly one thing
+- It should be small and focused
+- If it needs a comment to explain what it does, it should be split
+
+## DRY (Don't Repeat Yourself)
+
+- Extract repeated code into reusable functions
+- Share common logic through proper abstraction
+- Maintain single sources of truth
+
+## Verify Information
+
+Always verify information before presenting it. Do not make assumptions or speculate without clear evidence.

--- a/.github/instructions/coding-style.instructions.md
+++ b/.github/instructions/coding-style.instructions.md
@@ -1,0 +1,217 @@
+---
+applyTo: "**"
+description: "This file provides guidelines for coding-style instructionswriting"
+---
+
+## Type Definitions:
+
+- Prefer records for data types where appropriate:
+
+  ```csharp
+  // Good: Immutable data type with value semantics
+  public sealed record CustomerDto(string Name, Email Email);
+
+  // Avoid: Class with mutable properties
+  public class Customer
+  {
+      public string Name { get; set; }
+      public string Email { get; set; }
+  }
+  ```
+
+## Variable Declarations:
+
+- Use var where possible:
+
+  ```csharp
+  // Good: Using var for type inference
+  var fruit = "Apple";
+  var number = 42;
+  var order = new Order(fruit, number);
+  ```
+
+- Use pattern matching effectively:
+
+  ```csharp
+  // Good: Clear pattern matching
+  public decimal CalculateDiscount(Customer customer) =>
+      customer switch
+      {
+          { Tier: CustomerTier.Premium } => 0.2m,
+          { OrderCount: > 10 } => 0.1m,
+          _ => 0m
+      };
+
+  // Avoid: Nested if statements
+  public decimal CalculateDiscount(Customer customer)
+  {
+      if (customer.Tier == CustomerTier.Premium)
+          return 0.2m;
+      if (customer.OrderCount > 10)
+          return 0.1m;
+      return 0m;
+  }
+  ```
+
+## Nullability:
+
+- Mark nullable fields explicitly:
+
+  ```csharp
+  // Good: Explicit nullability
+  public class OrderProcessor
+  {
+      private readonly ILogger<OrderProcessor>? _logger;
+      private string? _lastError;
+
+      public OrderProcessor(ILogger<OrderProcessor>? logger = null)
+      {
+          _logger = logger;
+      }
+  }
+
+  // Avoid: Implicit nullability
+  public class OrderProcessor
+  {
+      private readonly ILogger<OrderProcessor> _logger; // Warning: Could be null
+      private string _lastError; // Warning: Could be null
+  }
+  ```
+
+- Use null checks only when necessary for reference types and public methods:
+
+  ```csharp
+  // Good: Proper null checking
+  public void ProcessOrder(Order order)
+  {
+      ArgumentNullException.ThrowIfNull(order); // Appropriate for reference types
+
+      _logger?.LogInformation("Processing order {Id}", order.Id);
+  }
+
+  // Good: Using pattern matching for null checks
+  public decimal CalculateTotal(Order? order) =>
+      order switch
+      {
+          null => throw new ArgumentNullException(nameof(order)),
+          { Lines: null } => throw new ArgumentException("Order lines cannot be null", nameof(order)),
+          _ => order.Lines.Sum(l => l.Total)
+      };
+  ```
+
+- Use init-only properties with non-null validation:
+
+  ```csharp
+  // Good: Non-null validation in constructor
+  public sealed record Order
+  {
+      public required OrderId Id { get; init; }
+      public required ImmutableList<OrderLine> Lines { get; init; }
+
+      public Order()
+      {
+          Id = null!; // Will be set by required property
+          Lines = null!; // Will be set by required property
+      }
+
+      private Order(OrderId id, ImmutableList<OrderLine> lines)
+      {
+          Id = id;
+          Lines = lines;
+      }
+
+      public static Order Create(OrderId id, IEnumerable<OrderLine> lines) =>
+          new(id, lines.ToImmutableList());
+  }
+  ```
+
+- Document nullability in interfaces:
+
+  ```csharp
+  public interface IOrderRepository
+  {
+      // Explicitly shows that null is a valid return value
+      Task<Order?> FindByIdAsync(OrderId id, CancellationToken ct = default);
+
+      // Method will never return null
+      [return: NotNull]
+      Task<IReadOnlyList<Order>> GetAllAsync(CancellationToken ct = default);
+
+      // Parameter cannot be null
+      Task SaveAsync([NotNull] Order order, CancellationToken ct = default);
+  }
+  ```
+
+## Safe Operations:
+
+- Use Try methods for safer operations:
+
+  ```csharp
+  // Good: Using TryGetValue for dictionary access
+  if (dictionary.TryGetValue(key, out var value))
+  {
+      // Use value safely here
+  }
+  else
+  {
+      // Handle missing key case
+  }
+
+  // Avoid: Direct indexing which can throw
+  var value = dictionary[key];  // Throws if key doesn't exist
+  ```
+
+  ```csharp
+  // Good: Using Uri.TryCreate for URL parsing
+  if (Uri.TryCreate(urlString, UriKind.Absolute, out var uri))
+  {
+      // Use uri safely here
+  }
+  else
+  {
+      // Handle invalid URL case
+  }
+
+  // Avoid: Direct Uri creation which can throw
+    var uri = new Uri(urlString);  // Throws on invalid URL
+  ```
+
+  ```csharp
+  // Good: Using int.TryParse for number parsing
+    if (int.TryParse(input, out var number))
+    {
+        // Use number safely here
+    }
+    else
+    {
+        // Handle invalid number case
+    }
+  ```
+
+  ```csharp
+    // Good: Combining Try methods with null coalescing
+    var value = dictionary.TryGetValue(key, out var result)
+        ? result
+        : defaultValue;
+
+    // Good: Using Try methods in LINQ with pattern matching
+    var validNumbers = strings
+        .Select(s => (Success: int.TryParse(s, out var num), Value: num))
+        .Where(x => x.Success)
+        .Select(x => x.Value);
+  ```
+
+## Asynchronous Programming:
+
+- Avoid use of Task.Result, Task.Wait, Task.FromResult.
+
+- Prefer async/await over direct Task return:
+  ```csharp
+  // Good: Using async/await
+  public async Task<Order> ProcessOrderAsync(OrderRequest request)
+  {
+      await _validator.ValidateAsync(request);
+      var order = await _factory.CreateAsync(request);
+      return order;
+  }
+  ```

--- a/.github/instructions/coding-style.instructions.md
+++ b/.github/instructions/coding-style.instructions.md
@@ -1,6 +1,6 @@
 ---
 applyTo: "**"
-description: "This file provides guidelines for coding-style instructionswriting"
+description: "This file provides guidelines for coding-style instructions writing"
 ---
 
 ## Type Definitions:

--- a/.gitignore
+++ b/.gitignore
@@ -59,9 +59,6 @@ coverage.cobertura.xml
 **/appsettings.Development.json
 **/appsettings.Local.json
 
-# Local-only GitHub Copilot instructions
-.github/copilot-instructions.md
-
 # ========================================
 # Operating System Files
 # ========================================

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,49 @@
+# Release v1.6.0
+
+## Overview
+
+This minor release introduces significant database schema improvements focused on data normalization and relationship modeling for education types. The changes replace the previous denormalized structure with proper many-to-many relationships, improving data integrity and enabling more flexible querying of educational profiles by their associated education types and ownership models.
+
+## New Features
+
+- **Enhanced Education Type Modeling**: Introduced proper many-to-many relationships between education types and institutional ownership
+- **Profile-Education Type Associations**: Replaced single education type column with flexible many-to-many mapping for profile details
+- **Data Integrity Improvements**: Added proper foreign key constraints and unique constraints for data consistency
+
+## Database Schema Changes
+
+### New Tables
+
+- **`[Application].[EducationType_Ownership]`**: Many-to-many mapping table between education types and institution ownership types
+
+  - Enables flexible associations between education types (e.g., "дневна", "вечерна") and ownership models (e.g., "държавна", "общинска", "частна")
+  - Includes proper constraints and unique key enforcement
+
+- **`[Application].[ProfileDetails_EducationType]`**: Many-to-many mapping table between profile details and education types
+  - Replaces the previous `EducatingType` column with normalized relationship structure
+  - Allows profiles to be associated with multiple education types where applicable
+
+### Structural Improvements
+
+- **Schema Normalization**: Removed direct ownership reference from `EducationType` table in favor of mapping table approach
+- **Duplicate Cleanup**: Automated removal of duplicate education type records while preserving data relationships
+
+### View Updates
+
+- **`[Application].[uv_ProfileDetails]`**: Updated to use new many-to-many relationship structure
+  - Modified JOIN logic to properly retrieve education type information through mapping tables
+  - Maintains backward compatibility for existing API endpoints
+
+## Technical Details
+
+### Breaking Changes
+
+**None - this is a schema enhancement with full backward compatibility.**
+
+The API endpoints continue to function exactly as before, with the view layer abstracting the underlying schema improvements.
+
+<br><br>
+
 # Release v1.5.1
 
 ## Overview

--- a/SchoolPortal.Database.Deploy/AlwaysRun/Views/[Application].[uv_ProfileDetails].sql
+++ b/SchoolPortal.Database.Deploy/AlwaysRun/Views/[Application].[uv_ProfileDetails].sql
@@ -10,7 +10,7 @@ SELECT
 	inst.[ShortName]					as InstitutionShortName,
 	pd.[GradingFormulas]				as GradingFormulas,
 	pd.[StudyMethod]					as StudyMethod,
-	pd.[EducatingType]					as EducationType,
+	et.[Name]							as EducationType,
 	pd.[ClassesCount]					as ClassesCount,
 	pd.[FirstForeignLanguage]			as FirstForeignLanguage,
 	scy.[Year]							as SchoolYear,
@@ -46,6 +46,8 @@ SELECT
 
 FROM	  [Application].[Profile]				as p
 LEFT JOIN [Application].[ProfileDetails]		as pd		ON pd.[ProfileId] = p.[Id]
+LEFT JOIN [Application].[ProfileDetails_EducationType] as pdet ON pd.[Id] = pdet.[ProfileDetailsId]
+LEFT JOIN [Application].[EducationType]			as et		ON pdet.[EducationTypeId] = et.[Id]
 LEFT JOIN [Application].[Specialty]				as sty		ON pd.[SpecialtyId] = sty.[Id]
 LEFT JOIN [Application].[Profession]			as prof		ON sty.[ProfessionId] = prof.[Id]
 LEFT JOIN [Application].[ProfessionalDirection] as profd	ON prof.[ProfessionalDirectionId] = profd.[Id]

--- a/SchoolPortal.Database.Deploy/Scripts/007_educationType-ownership-mapping.sql
+++ b/SchoolPortal.Database.Deploy/Scripts/007_educationType-ownership-mapping.sql
@@ -1,0 +1,20 @@
+CREATE TABLE [Application].[EducationType_Ownership]
+(
+    [Id]              INT NOT NULL IDENTITY (1, 1),
+    [EducationTypeId] INT NOT NULL,
+    [OwnershipId]     INT NOT NULL,
+
+    CONSTRAINT [PK_EducationTypeOwnership_Id] PRIMARY KEY CLUSTERED ([Id]),
+    CONSTRAINT [FK_EducationTypeOwnership_EducationTypeId] FOREIGN KEY ([EducationTypeId]) REFERENCES [Application].[EducationType] ([Id]),
+    CONSTRAINT [FK_EducationTypeOwnership_OwnershipId] FOREIGN KEY ([OwnershipId]) REFERENCES [Application].[InstitutionOwnership] ([Id]),
+    CONSTRAINT [UQ_EducationTypeOwnership_EducationTypeId_OwnershipId] UNIQUE ([EducationTypeId], [OwnershipId])
+);
+GO
+
+ALTER TABLE [Application].[EducationType]
+DROP CONSTRAINT [FK_EducationType_OwnershipId];
+GO
+
+ALTER TABLE [Application].[EducationType]
+DROP COLUMN [OwnershipId];
+GO

--- a/SchoolPortal.Database.Deploy/Scripts/008_profileDetails-educationType-mapping.sql
+++ b/SchoolPortal.Database.Deploy/Scripts/008_profileDetails-educationType-mapping.sql
@@ -1,0 +1,16 @@
+CREATE TABLE [Application].[ProfileDetails_EducationType]
+(
+    [Id]                INT NOT NULL IDENTITY (1, 1),
+    [ProfileDetailsId]  INT NOT NULL,
+    [EducationTypeId]   INT NOT NULL,
+
+    CONSTRAINT [PK_ProfileDetailsEducationType_Id] PRIMARY KEY CLUSTERED ([Id]),
+    CONSTRAINT [FK_ProfileDetailsEducationType_ProfileDetailsId] FOREIGN KEY ([ProfileDetailsId]) REFERENCES [Application].[ProfileDetails] ([Id]),
+    CONSTRAINT [FK_ProfileDetailsEducationType_EducationTypeId] FOREIGN KEY ([EducationTypeId]) REFERENCES [Application].[EducationType] ([Id]),
+    CONSTRAINT [UQ_ProfileDetailsEducationType_ProfileDetailsId_EducationTypeId] UNIQUE ([ProfileDetailsId], [EducationTypeId])
+);
+GO
+
+ALTER TABLE [Application].[ProfileDetails]
+DROP COLUMN [EducatingType];
+GO


### PR DESCRIPTION
### Refactor 'ProfileDetails' table to reference the 'EducationType' table instead of  'EducatingType' column.

### Description:
Remove the existing `EducatingType` column from the `ProfileDetails` table and replace its usage with references to the new `EducationType` table. This change will normalize the schema and align profile data with the new structure.

### Action Plan:

1.  The `EducationType` table currently contains duplicate values based on `Ownership`.
    
    *   Remove duplicates, keeping only unique values.
        
    *   Remove the `OwnershipId` column.
        
2.  Create a new mapping table, `EducationTypeOwnership`, to link each ownership with its available education types.
    
3.  Create a mapping table, `ProfileDetailsEducationType`, to link each profile to its correct education type.
    
4.  Update the `ProfileDetails` table:
    
    *   Remove the `EducatingType` column.
        
    *   Add a reference to the appropriate ID from the new mapping table.
        
5.  Update any related views, stored procedures, and API models as needed.